### PR TITLE
Better generation of Logout URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,16 @@
             <version>2.3.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-spec</artifactId>
+            <version>1.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
+            <version>1.2.5</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,4 +1,5 @@
-<%@page import="org.pac4j.core.context.*"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page import="org.pac4j.core.context.*" %>
 <%@ page import="org.pac4j.core.profile.ProfileManager" %>
 <%
 	WebContext context = new J2EContext(request, response);
@@ -24,9 +25,9 @@
 <br />
 <a href="forceLogin?client_name=FacebookClient">Force Facebook login</a> (even if already authenticated)<br />
 <br />
-<a href="/logout?url=/?forcepostlogouturl">local logout</a><br />
-<br />
-<a href="/centralLogout?url=http://localhost:8080/?forcepostlogouturlafteridp">central logout</a>
+<a href="logout?url=<c:url value="/?forcepostlogouturl"/>">local logout</a>
+<br /><br />
+<a href="centralLogout?url=<c:url value="/?forcepostlogouturlafteridp"/>">central logout</a>
 <br /><br />
 profiles: <%=manager.getAll(true)%><br />
 <br />


### PR DESCRIPTION
Tiny change of logout URLs (local + central). They are now generated
dynamically with c:url, so the demo application can be deployed on any
context and port. Just for ease of testing.
Apache taglibs, latest version, added to the POM to enable the core
taglib on the index page.